### PR TITLE
Fix ContextVar deprecation warning by passing config_entry

### DIFF
--- a/custom_components/anker_solix/coordinator.py
+++ b/custom_components/anker_solix/coordinator.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import logging
 from asyncio import TimerHandle, sleep
 from datetime import datetime, timedelta
-import logging
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -47,6 +47,7 @@ class AnkerSolixDataUpdateCoordinator(DataUpdateCoordinator):
         super().__init__(
             hass=hass,
             logger=LOGGER,
+            config_entry=config_entry,
             name=f"{DOMAIN}_{config_entry.title}",
             update_interval=timedelta(seconds=update_interval),
         )
@@ -54,10 +55,7 @@ class AnkerSolixDataUpdateCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self) -> dict:
         """Update data via library."""
         try:
-            if (
-                not await self.client.validate_cache()
-                or self.client.active_device_refresh
-            ):
+            if not await self.client.validate_cache() or self.client.active_device_refresh:
                 # return existing data if cache stays invalid during systems export randomization or manual update still active
                 return self.data
             # stagger non-initial updates if required
@@ -67,13 +65,9 @@ class AnkerSolixDataUpdateCoordinator(DataUpdateCoordinator):
             data = await self.client.async_get_data()
             # make sure deferred data will create additional entities
             if self.client.deferred_data and self.config_entry:
-                if await self.hass.config_entries.async_unload_platforms(
-                    self.config_entry, PLATFORMS
-                ):
+                if await self.hass.config_entries.async_unload_platforms(self.config_entry, PLATFORMS):
                     self.client.deferred_data = False
-                    await self.hass.config_entries.async_forward_entry_setups(
-                        self.config_entry, PLATFORMS
-                    )
+                    await self.hass.config_entries.async_forward_entry_setups(self.config_entry, PLATFORMS)
         except (
             AnkerSolixApiClientAuthenticationError,
             AnkerSolixApiClientRetryExceededError,
@@ -96,9 +90,7 @@ class AnkerSolixDataUpdateCoordinator(DataUpdateCoordinator):
         self.data = await self.client.async_get_data(from_cache=True)
         if delayed and not self.update_handler:
             # get handler for delayed listener update
-            self.update_handler = self.hass.loop.call_later(
-                delay=(delay := 2.0), callback=self.async_update_listeners
-            )
+            self.update_handler = self.hass.loop.call_later(delay=(delay := 2.0), callback=self.async_update_listeners)
             LOGGER.log(
                 logging.INFO if ALLOW_TESTMODE else logging.DEBUG,
                 "Coordinator %s delayed listener update for %s seconds during entity restore processing",
@@ -122,20 +114,14 @@ class AnkerSolixDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def async_refresh_device_details(self, reset_cache: bool = False) -> None:
         """Update data including device details and reset update interval."""
-        data = await self.client.async_get_data(
-            device_details=True, reset_cache=reset_cache
-        )
+        data = await self.client.async_get_data(device_details=True, reset_cache=reset_cache)
         if reset_cache:
             # ensure to refresh entity setup when cache was reset to unload all entities and reload remaining entities
             # This will also restore states from previous state in state machine if required
             self.data = data
-            if await self.hass.config_entries.async_unload_platforms(
-                self.config_entry, PLATFORMS
-            ):
+            if await self.hass.config_entries.async_unload_platforms(self.config_entry, PLATFORMS):
                 # refresh restore state cache
-                await self.hass.config_entries.async_forward_entry_setups(
-                    self.config_entry, PLATFORMS
-                )
+                await self.hass.config_entries.async_forward_entry_setups(self.config_entry, PLATFORMS)
         else:
             # update only coordinator data and notify listeners
             self.async_set_updated_data(data)
@@ -161,14 +147,9 @@ class AnkerSolixDataUpdateCoordinator(DataUpdateCoordinator):
         """Introduce a refresh delay for staggered data collection."""
 
         # stagger interval for sites update cycle
-        sites_shift = timedelta(
-            seconds=5
-        )  # if self.client.startup else timedelta(seconds=10)
+        sites_shift = timedelta(seconds=5)  # if self.client.startup else timedelta(seconds=10)
         # get all defined config entries
-        cfg_ids: list[str] = [
-            cfg.entry_id
-            for cfg in self.hass.config_entries.async_entries(domain=DOMAIN)
-        ]
+        cfg_ids: list[str] = [cfg.entry_id for cfg in self.hass.config_entries.async_entries(domain=DOMAIN)]
         # hass data contains only completely loaded configuration IDs (with coordinators)
         # exclude own coordinator if active already
         active_crds: list[AnkerSolixDataUpdateCoordinator] = [
@@ -178,8 +159,7 @@ class AnkerSolixDataUpdateCoordinator(DataUpdateCoordinator):
         ]
         # determine a staggered delay based on last data collections of active coordinators or configuration index if none active yet
         next_refreshes: list[datetime] = [
-            c.client.last_site_refresh + c.update_interval + timedelta(seconds=5)
-            for c in active_crds
+            c.client.last_site_refresh + c.update_interval + timedelta(seconds=5) for c in active_crds
         ]
         next_refreshes.sort()
         # find next 10 sec gap in active clients
@@ -194,10 +174,7 @@ class AnkerSolixDataUpdateCoordinator(DataUpdateCoordinator):
         if delay is None:
             # set delay according config index or next possible start time
             delay = (
-                int(
-                    sites_shift.total_seconds()
-                    * cfg_ids.index(self.config_entry.entry_id)
-                )
+                int(sites_shift.total_seconds() * cfg_ids.index(self.config_entry.entry_id))
                 if start_time <= time_now
                 else int((start_time - time_now).total_seconds())
             )
@@ -211,9 +188,7 @@ class AnkerSolixDataUpdateCoordinator(DataUpdateCoordinator):
                 int(delay),
             )
             # delay also last refresh to allow other clients proper next refresh check
-            self.client.last_site_refresh = self.client.last_site_refresh + timedelta(
-                seconds=delay
-            )
+            self.client.last_site_refresh = self.client.last_site_refresh + timedelta(seconds=delay)
             await sleep(delay)
 
     async def async_details_delay(self) -> None:
@@ -225,22 +200,16 @@ class AnkerSolixDataUpdateCoordinator(DataUpdateCoordinator):
         elif self.details_delayed:
             # Adjust projected starttime
             self.details_delayed = (
-                datetime.now().astimezone()
-                + (self.client.intervalcount() - 1) * self.update_interval
+                datetime.now().astimezone() + (self.client.intervalcount() - 1) * self.update_interval
             )
         # return if delay should be skipped
-        if (
-            (count := self.client.intervalcount()) > 1
-            or self.client.deviceintervals() <= 2
-            or self.details_delayed
-        ):
+        if (count := self.client.intervalcount()) > 1 or self.client.deviceintervals() <= 2 or self.details_delayed:
             return
         # ignore own and short interval coordinators for active coordinators
         active_crds: list[AnkerSolixDataUpdateCoordinator] = [
             c
             for c in (self.hass.data.get(DOMAIN) or {}).values()
-            if c.config_entry.entry_id != self.config_entry.entry_id
-            and c.client.deviceintervals() > 2
+            if c.config_entry.entry_id != self.config_entry.entry_id and c.client.deviceintervals() > 2
         ]
         # determine a staggered delay based on running or delayed clients that cannot be delayed further
         durations: list[timedelta] = [
@@ -267,7 +236,4 @@ class AnkerSolixDataUpdateCoordinator(DataUpdateCoordinator):
             )
             self.client.intervalcount(count + details_shift)
             # calculate projected start time
-            self.details_delayed = (
-                datetime.now().astimezone()
-                + (count + details_shift - 1) * self.update_interval
-            )
+            self.details_delayed = datetime.now().astimezone() + (count + details_shift - 1) * self.update_interval


### PR DESCRIPTION
Your great Anker-Solix integration was triggering a deprecation warning in Home Assistant 2025.8.0b0:

`WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration 'anker_solix' relies on ContextVar, but should pass the config entry explicitly. at custom_components/anker_solix/coordinator.py, line 47: super().__init__(. This will stop working in Home Assistant 2026.8, please create a bug report at https://github.com/thomluther/ha-anker-solix/issues
`
The issue was that AnkerSolixDataUpdateCoordinator was not explicitly passing the config_entry parameter to the parent DataUpdateCoordinator constructor, causing it to fall back to using ContextVar to retrieve the config entry.