### PR TITLE
Integration fails on HA 2025.10.0 + due to removed argument description_placeholders in HA

### DIFF
--- a/custom_components/anker_solix/services.py
+++ b/custom_components/anker_solix/services.py
@@ -71,9 +71,6 @@ def async_setup_services(hass: HomeAssistant) -> None:
         entity_domain=switch.DOMAIN,
         schema=SOLIX_REQUEST_SCHEMA,
         func=SERVICE_API_REQUEST,
-        description_placeholders={
-            "url": REQUEST_LINK,
-        },
         required_features=[AnkerSolixEntityFeature.ACCOUNT_INFO],
         supports_response=SupportsResponse.ONLY,
     )


### PR DESCRIPTION
Hello,

Since a few months (Oct 2025) I have been using the HACS ha-anker-solix integration for my Anker Solix batteries. It works quite well — thank you for that!

Today I encountered problems after upgrading to the latest version of the ha-anker-solix integration together with the latest version of Home Assistant.

It seems that Home Assistant has updated its API and the argument description_placeholders is no longer available.
That’s why the integration failed during the startup of Home Assistant.

With some help from Copilot I removed the unsupported argument in the services.py file. After this change and a restart of Home Assistant, everything worked fine again.