### PR TITLE
Add as220 s2000 support

### DIFF
--- a/custom_components/anker_solix/binary_sensor.py
+++ b/custom_components/anker_solix/binary_sensor.py
@@ -45,6 +45,25 @@ from .solixapi.apitypes import SolarbankAiemsStatus, SolixDeviceType, SolixNetwo
 from .solixapi.helpers import get_enum_name
 from .solixapi.mqtt_device import SolixMqttDevice
 
+_WEEKDAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
+
+def _weekday_names(mask: int | None) -> str | None:
+    """Return comma-joined weekday names from a bit0=Mon..bit6=Sun bitmask."""
+    if mask is None:
+        return None
+    return (
+        ",".join(name for i, name in enumerate(_WEEKDAY_NAMES) if int(mask) & (1 << i))
+        or "none"
+    )
+
+
+def _min_to_hhmm(minutes: int | None) -> str | None:
+    """Return HH:MM from a minutes-of-day value."""
+    if minutes is None:
+        return None
+    return f"{int(minutes) // 60:02d}:{int(minutes) % 60:02d}"
+
 
 @dataclass(frozen=True)
 class AnkerSolixBinarySensorDescription(
@@ -78,6 +97,51 @@ DEVICE_SENSORS = [
             "wireless_type": d.get("wireless_type"),
         },
         exclude_fn=lambda s, d: not ({d.get("type")} - s),
+    ),
+    AnkerSolixBinarySensorDescription(
+        # AS220 (S2000) silent-mode schedule (df telemetry)
+        key="silent_mode",
+        translation_key="silent_mode",
+        json_key="silent_mode_enabled",
+        value_fn=lambda d, jk: (
+            d.get(jk)
+            if d.get(jk) is not None
+            else (False if d.get("device_pn") == "AS220" else None)
+        ),
+        entity_category=EntityCategory.DIAGNOSTIC,
+        attrib_fn=lambda d: {
+            k: v
+            for k, v in {
+                "weekdays": _weekday_names(d.get("silent_mode_weekdays")),
+                "start": _min_to_hhmm(d.get("silent_mode_start_min")),
+                "end": _min_to_hhmm(d.get("silent_mode_end_min")),
+            }.items()
+            if v is not None
+        },
+        exclude_fn=lambda s, d: not ({d.get("type")} - s),
+        mqtt=True,
+    ),
+    AnkerSolixBinarySensorDescription(
+        # AS220 (S2000) custom charge/discharge schedule (dd telemetry)
+        key="custom_mode",
+        translation_key="custom_mode",
+        json_key="custom_mode_enabled",
+        value_fn=lambda d, jk: (
+            d.get(jk)
+            if d.get(jk) is not None
+            else (False if d.get("device_pn") == "AS220" else None)
+        ),
+        entity_category=EntityCategory.DIAGNOSTIC,
+        attrib_fn=lambda d: {
+            k: v
+            for k, v in {
+                "weekdays": _weekday_names(d.get("custom_mode_weekdays")),
+                "slots": d.get("custom_mode_slot_count"),
+            }.items()
+            if v is not None
+        },
+        exclude_fn=lambda s, d: not ({d.get("type")} - s),
+        mqtt=True,
     ),
     AnkerSolixBinarySensorDescription(
         key="wired_connection",

--- a/custom_components/anker_solix/icons.json
+++ b/custom_components/anker_solix/icons.json
@@ -46,6 +46,20 @@
             }
         },
         "binary_sensor": {
+            "silent_mode": {
+                "default": "mdi:volume-off",
+                "state": {
+                    "on": "mdi:volume-off",
+                    "off": "mdi:volume-high"
+                }
+            },
+            "custom_mode": {
+                "default": "mdi:calendar-clock",
+                "state": {
+                    "on": "mdi:calendar-clock",
+                    "off": "mdi:calendar-blank-outline"
+                }
+            },
             "wifi_connection": {
                 "default": "mdi:wifi-alert",
                 "state": {
@@ -526,6 +540,21 @@
             },
             "ac_input_power": {
                 "default": "mdi:power-plug-battery-outline"
+            },
+            "ac_output_working_mode": {
+                "default": "mdi:home-lightning-bolt-outline",
+                "state": {
+                    "standard": "mdi:power-plug-outline",
+                    "time_of_use": "mdi:cash-clock",
+                    "self_consumption": "mdi:home-battery-outline",
+                    "custom": "mdi:calendar-edit"
+                }
+            },
+            "backup_power_soc": {
+                "default": "mdi:battery-lock"
+            },
+            "smart_ac_output_timeout": {
+                "default": "mdi:timer-cog-outline"
             },
             "ac_input_power_total": {
                 "default": "mdi:power-plug-battery-outline"

--- a/custom_components/anker_solix/sensor.py
+++ b/custom_components/anker_solix/sensor.py
@@ -2042,6 +2042,59 @@ DEVICE_SENSORS = [
         exclude_fn=lambda s, d: not ({d.get("type")} - s),
         mqtt=True,
     ),
+    AnkerSolixSensorDescription(
+        # AS220 (S2000) active AC output working mode (from d9 telemetry)
+        key="ac_output_working_mode",
+        translation_key="ac_output_working_mode",
+        json_key="output_mode",
+        force_creation_fn=lambda d: d.get("device_pn") == "AS220",
+        device_class=SensorDeviceClass.ENUM,
+        options=["standard", "time_of_use", "self_consumption", "custom"],
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda d, jk, _: {
+            0: "standard",
+            1: "time_of_use",
+            2: "self_consumption",
+            3: "custom",
+        }.get(d.get(jk)),
+        attrib_fn=lambda d, _: {
+            k: v
+            for k, v in {
+                "mode_code": d.get("output_mode_raw"),
+                "backup_power_soc": d.get("backup_power_soc"),
+                "max_soc": d.get("max_soc"),
+                "tou_period_count": d.get("tou_period_count"),
+            }.items()
+            if v is not None
+        },
+        exclude_fn=lambda s, d: not ({d.get("type")} - s),
+        mqtt=True,
+    ),
+    AnkerSolixSensorDescription(
+        # AS220 (S2000) backup power reserve setpoint
+        key="backup_power_soc",
+        translation_key="backup_power_soc",
+        json_key="backup_power_soc",
+        force_creation_fn=lambda d: d.get("device_pn") == "AS220",
+        native_unit_of_measurement=PERCENTAGE,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=0,
+        exclude_fn=lambda s, d: not ({d.get("type")} - s),
+        mqtt=True,
+    ),
+    AnkerSolixSensorDescription(
+        # AS220 (S2000) smart AC output auto-off timeout
+        key="smart_ac_output_timeout",
+        translation_key="smart_ac_output_timeout",
+        json_key="smart_ac_output_timeout",
+        force_creation_fn=lambda d: d.get("device_pn") == "AS220",
+        value_fn=lambda d, jk, _: (
+            None if (v := d.get(jk)) is None else timedelta(minutes=v)
+        ),
+        entity_category=EntityCategory.DIAGNOSTIC,
+        exclude_fn=lambda s, d: not ({d.get("type")} - s),
+        mqtt=True,
+    ),
     # repeated element
     *[
         AnkerSolixSensorDescription(

--- a/custom_components/anker_solix/solixapi/apitypes.py
+++ b/custom_components/anker_solix/solixapi/apitypes.py
@@ -745,6 +745,7 @@ AE1R0  Anker SOLIX P1 Meter                     Accessory
 AE1X0  Smart Meter Gen 2                        Accessory
 AS100  C1000 Gen 2 LE                           Portable Power Station
 AS200  Alternator Charger                       Charger
+AS220  SOLIX S2000                              Portable Power Station
 AX1S0  Power Dock Pro                           Residential Storage System
 AX170  Power Dock                               Home Backup System
 A17E1  Anker SOLIX E10                          Home Backup System
@@ -1221,6 +1222,7 @@ class SolixDeviceCapacity:
     A1785: int = (
         2048  # SOLIX C2000X Gen 2 Portable Power Station with Smart Meter support
     )
+    AS220: int = 2000  # SOLIX S2000 Portable Power Station (2009.6 Wh)
     A1790: int = 3840  # SOLIX F3800 Portable Power Station
     A1790_1: int = 3840  # SOLIX BP3800 Expansion Battery for F3800
     A1790P: int = 3840  # SOLIX F3800 Plus Portable Power Station
@@ -1352,6 +1354,7 @@ class SolixDeviceCategory:
     A1785: str = (
         SolixDeviceType.PPS.value
     )  # SOLIX C2000X Gen 2 Portable Power Station with Smart Meter support
+    AS220: str = SolixDeviceType.PPS.value  # SOLIX S2000 Portable Power Station
     A1790: str = SolixDeviceType.PPS.value  # SOLIX F3800 Portable Power Station
     A1790P: str = SolixDeviceType.PPS.value  # SOLIX F3800 Plus Portable Power Station
     # Solarbank PPS devices

--- a/custom_components/anker_solix/solixapi/mqtt_pps.py
+++ b/custom_components/anker_solix/solixapi/mqtt_pps.py
@@ -40,6 +40,7 @@ MODELS = {
     "A1783",  # SOLIX C2000 Gen 2
     "A1790",  # SOLIX F3800 Power Panel PPS
     "A1790P",  # SOLIX F3800 Plus Power Panel PPS
+    "AS220",  # SOLIX S2000
 }
 
 # Define possible controls per Model

--- a/custom_components/anker_solix/solixapi/mqttmap.py
+++ b/custom_components/anker_solix/solixapi/mqttmap.py
@@ -3794,6 +3794,367 @@ _AS200_0421 = {
     },
 }
 
+# S2000 telemetry - forked from _A1783_0421 (C2000 Gen 2); extra AS220-only tags TBD
+_AS220_0421 = {
+    "a2": {
+        BYTES: {
+            "01": {
+                NAME: "device_sn",
+                TYPE: DeviceHexDataTypes.str.value,
+            },
+            "20": {
+                NAME: "device_pn",
+                TYPE: DeviceHexDataTypes.str.value,
+            },
+        }
+    },
+    "a3": {
+        BYTES: {
+            "00": {
+                NAME: "charging_status",  # (0-3): Inactive (0), DC Input (1), AC Input (2), Both (3)?
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "04": {
+                NAME: "ac_input_limit_max",  # Max supported charge limit, seems fix
+                TYPE: DeviceHexDataTypes.sile.value,
+            },
+            "06": {
+                NAME: "unknown_a3_06",
+                TYPE: DeviceHexDataTypes.sile.value,
+            },
+            "07": {
+                NAME: "unknown_a3_07",
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "08": {
+                NAME: "unknown_a3_08",
+                TYPE: DeviceHexDataTypes.sile.value,
+            },
+            "10": {
+                NAME: "unknown_a3_10",
+                TYPE: DeviceHexDataTypes.sile.value,
+            },
+        }
+    },
+    "a4": {
+        BYTES: {
+            "00": {
+                NAME: "ac_output_timeout_seconds",  # disable (0), min:0, max: 86400, step 300
+                TYPE: DeviceHexDataTypes.var.value,
+                LENGTH: 4,
+            },
+            "04": {
+                NAME: "ac_input_limit",  # AC charge limit: 100-2400 W, step: 100
+                TYPE: DeviceHexDataTypes.sile.value,
+            },
+            "06": {
+                NAME: "ac_frequency",  # 60 / 50 Hz
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "08": {
+                NAME: "dc_output_timeout_seconds",  # disable (0), min:0, max: 86400, step 300
+                TYPE: DeviceHexDataTypes.var.value,
+                LENGTH: 4,
+            },
+            "13": {
+                NAME: "device_timeout_minutes",  # 0 (Never), 30, 60, 120, 240, 360, 720, 1440
+                TYPE: DeviceHexDataTypes.sile.value,
+            },
+            "15": {
+                NAME: "display_timeout_seconds",  # 0 (Never), 10, 30, 60, 300, 1800
+                TYPE: DeviceHexDataTypes.sile.value,
+            },
+            "17": {
+                NAME: "display_mode",  # Low (1), Medium (2), High (3)
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "19": {
+                NAME: "temp_unit_fahrenheit",  # Celsius (0) or Fahrenheit (1)
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "20": {
+                NAME: "ac_fast_charge_switch",  # Ultrafast Charge switch: Disabled (0) or Enabled (1)
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "21": {
+                NAME: "display_switch",  # Off (0), On (1)
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "22": {
+                NAME: "port_memory_switch",  # Output Port Memory switch: Disabled (0) or Enabled (1)
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "28": {
+                NAME: "smart_ac_output_timeout",  # minutes; AS220 replaces ac_output_timeout_seconds (live: 240=4h, 720=12h)
+                TYPE: DeviceHexDataTypes.sile.value,
+            },
+        }
+    },
+    "a5": {
+        BYTES: {
+            "00": {
+                NAME: "temperature",
+                SIGNED: True,
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "01": {
+                NAME: "charging_status_a5_1?",  # (0-3): Inactive (0), DC Input (1), AC Input (2), Both (3)
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "02": {
+                NAME: "battery_soc",  # Total SOC of main + Exp batteries?
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+        }
+    },
+    "a6": {
+        BYTES: {
+            "00": {
+                NAME: "output_power_total",  # Output power total (AC + DC)
+                TYPE: DeviceHexDataTypes.sile.value,
+            },
+            "02": {
+                NAME: "ac_input_power",  # Input power total charge
+                TYPE: DeviceHexDataTypes.sile.value,
+            },
+            "04": {
+                NAME: "dc_input_power_total",  # # DC input power (solar + car charging)
+                TYPE: DeviceHexDataTypes.sile.value,
+            },
+            "06": {
+                NAME: "remaining_time_hours",  # hours with factor 0.1
+                TYPE: DeviceHexDataTypes.sile.value,
+                FACTOR: 0.1,
+                SIGNED: False,
+            },
+            "08": {
+                NAME: "main_battery_soc?",  # SOC of main battery only?
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+        },
+    },
+    "a7": {
+        BYTES: {
+            "00": {
+                NAME: "ac_output_power_switch",  # Off (0), On (1)
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "01": {
+                NAME: "ac_output_power",  # AC Output power
+                TYPE: DeviceHexDataTypes.sile.value,
+            },
+            "03": {
+                NAME: "ac_input_switch",  # AC input / charging active (0/1) - live-confirmed: 0->1 when charging
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "04": {
+                NAME: "ac_input_power_a7",  # AC input power (dup of a6 ac_input_power) - live-confirmed = input W
+                TYPE: DeviceHexDataTypes.sile.value,
+            },
+        }
+    },
+    "aa": {
+        BYTES: {
+            "00": {
+                NAME: "usbc_1_status",  # USB-C 1 status: Inactive (0), Discharging (1), Charging (2)
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "01": {
+                NAME: "usbc_1_power",
+                TYPE: DeviceHexDataTypes.sile.value,
+            },
+        }
+    },
+    "ab": {
+        BYTES: {
+            "00": {
+                NAME: "usbc_2_status",  # USB-C 2 status: Inactive (0), Discharging (1), Charging (2)
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "01": {
+                NAME: "usbc_2_power",
+                TYPE: DeviceHexDataTypes.sile.value,
+            },
+        }
+    },
+    "ac": {
+        BYTES: {
+            "00": {
+                NAME: "usbc_3_status",  # USB-C 3 status: Inactive (0), Discharging (1), Charging (2)
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "01": {
+                NAME: "usbc_3_power",
+                TYPE: DeviceHexDataTypes.sile.value,
+            },
+        }
+    },
+    "ae": {
+        BYTES: {
+            "00": {
+                NAME: "usba_1_status",  # USB-A 1 status: Inactive (0), Discharging (1), Charging (2)
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "01": {
+                NAME: "usba_1_power",
+                TYPE: DeviceHexDataTypes.sile.value,
+            },
+        }
+    },
+    "b2": {
+        BYTES: {
+            "00": {
+                NAME: "dc_output_power_switch",  # Off (0), On (1)
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "01": {
+                NAME: "dc_output_power_total",  # Total Watt DC
+                TYPE: DeviceHexDataTypes.sile.value,
+            },
+        }
+    },
+    "c0": {
+        BYTES: [
+            # Field has flexible byte offsets, depending on SN length
+            {
+                NAME: "exp_1_sn",
+                TYPE: DeviceHexDataTypes.str.value,
+            },
+            {
+                NAME: "exp_1_temperature",
+                TYPE: DeviceHexDataTypes.ui.value,
+                SIGNED: True,
+                OFFSET: 5,
+            },
+            {
+                NAME: "exp_1_soc",
+                TYPE: DeviceHexDataTypes.ui.value,
+                OFFSET: 1,
+            },
+            {
+                NAME: "exp_1_type",
+                TYPE: DeviceHexDataTypes.str.value,
+                OFFSET: 6,
+            },
+        ]
+    },
+    "ce": {
+        BYTES: {
+            "00": {
+                NAME: "device_1_pn",
+                TYPE: DeviceHexDataTypes.str.value,
+            },
+            "18": {
+                NAME: "device_1_sn",
+                TYPE: DeviceHexDataTypes.str.value,
+            },
+            "40": {
+                NAME: "device_1_mode",  # reverse charge (1), charge (2), standby (3)
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "41": {
+                NAME: "device_1_output_power",
+                TYPE: DeviceHexDataTypes.sile.value,
+            },
+        }
+    },
+    "d9": {
+        # AS220: AC-output mode selector + backup + Time-of-Use plan (layout differs from A1783).
+        # Byte 6+ holds the TOU schedule: {period_type(1=Peak,2=Mid,3=Off), start_hr, end_hr} x tou_period_count.
+        BYTES: {
+            "00": {
+                NAME: "output_mode_raw",  # 0=Standard/UPS, 3=Time-of-Use, 4=Self-Consumption, 5=Custom
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "01": {
+                NAME: "output_mode",  # 0-based: 0=Standard, 1=Time-of-Use, 2=Self-Consumption, 3=Custom
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "02": {
+                NAME: "backup_power_soc",  # backup reserve % (discharge floor)
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "03": {
+                NAME: "max_soc",  # max_soc %
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "04": {
+                NAME: "min_soc",  # min_soc % - restored from A1783 template; feeds soc_min / power_cutoff
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "05": {
+                NAME: "tou_period_count",  # number of Time-of-Use periods following at byte 6+
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+        }
+    },
+    "da": {
+        BYTES: {
+            "19": {
+                NAME: "charger_status_da_10?",
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "12": {
+                NAME: "unknown_da_12?",
+                TYPE: DeviceHexDataTypes.sile.value,
+            },
+            "14": {
+                NAME: "unknown_da_14?",
+                TYPE: DeviceHexDataTypes.sile.value,
+            },
+        }
+    },
+    "dd": {
+        # Custom-mode charge/discharge schedule (live-confirmed vs app).
+        # Byte 3+ holds slots: {action(1=charge,2=discharge), start_min(u16 LE), end_min(u16 LE)} x custom_mode_slot_count.
+        BYTES: {
+            "00": {
+                NAME: "custom_mode_enabled",  # 0/1
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "01": {
+                NAME: "custom_mode_weekdays",  # bitmask bit0=Mon..bit6=Sun (0x1f=Mon-Fri)
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "02": {
+                NAME: "custom_mode_slot_count",
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+        }
+    },
+    "df": {
+        # Silent-mode schedule (live-confirmed vs app)
+        BYTES: {
+            "00": {
+                NAME: "silent_mode_enabled",  # 0/1
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "01": {
+                NAME: "silent_mode_weekdays",  # bitmask bit0=Mon..bit6=Sun (0x7f=all, 0x1f=Mon-Fri)
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "02": {
+                NAME: "silent_mode_start_min",  # start, minutes of day (u16 LE)
+                TYPE: DeviceHexDataTypes.sile.value,
+            },
+            "04": {
+                NAME: "silent_mode_end_min",  # end, minutes of day (u16 LE)
+                TYPE: DeviceHexDataTypes.sile.value,
+            },
+        }
+    },
+    "f0": {
+        BYTES: {
+            "00": {
+                NAME: "ac_output_switch_f0",  # dup of ac_output_power_switch - live-confirmed via isolation test
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+        }
+    },
+    "fd": {NAME: "utc_timestamp"},
+    "fe": {NAME: "msg_timestamp"},
+}
+
 _PLUG_TIMER_STATUS = {
     BYTES: {
         "00": {
@@ -6431,6 +6792,151 @@ SOLIXMQTTMAP: Final[dict] = {
         "0421": _AS200_0421,
         # Interval: ~every 5 minutes, same content as 0421
         "0900": _AS200_0421,
+    },
+    # PPS S2000 - telemetry matches A1783 (C2000 Gen 2); 0101-0103 controls inherited, not yet validated
+    "AS220": {
+        "0057": CMD_REALTIME_TRIGGER,  # for regular status messages 0405 etc
+        "0101": {
+            # AC command group
+            COMMAND_LIST: [
+                SolixMqttCommands.ac_output_switch,  # field a2
+                SolixMqttCommands.ac_output_timeout_seconds,  # field a3
+                SolixMqttCommands.ac_charge_limit,  # field a4
+                SolixMqttCommands.ac_output_mode_select,  # field a6
+            ],
+            SolixMqttCommands.ac_output_switch: CMD_COMMON_V2
+            | {
+                "a2": {
+                    NAME: "set_ac_output_switch",  # Disable (0) | Enable (1)
+                    TYPE: DeviceHexDataTypes.ui.value,
+                    STATE_NAME: "ac_output_power_switch",
+                    VALUE_OPTIONS: {"off": 0, "on": 1},
+                },
+            },
+            SolixMqttCommands.ac_charge_limit: CMD_COMMON_V2
+            | {
+                "a4": {
+                    NAME: "set_ac_input_limit",  # in W; min: 200, max: 1800-2400, step: 100
+                    TYPE: DeviceHexDataTypes.sile.value,
+                    STATE_NAME: "ac_input_limit",
+                    VALUE_MIN: 200,
+                    VALUE_MAX: 1800,  # lowest limit for all variants
+                    VALUE_MAX_STATE: "ac_input_limit_max",  # adopt limit based on device variant
+                    VALUE_STEP: 100,
+                },
+            },
+            SolixMqttCommands.ac_output_timeout_seconds: CMD_COMMON_V2
+            | {
+                "a3": {
+                    NAME: "set_ac_output_timeout_seconds",  # Timeout seconds, custom range: 0-86400, step 300
+                    TYPE: DeviceHexDataTypes.var.value,
+                    STATE_NAME: "ac_output_timeout_seconds",
+                    VALUE_MIN: 0,
+                    VALUE_MAX: 86400,
+                    VALUE_STEP: 300,
+                },
+            },
+            SolixMqttCommands.ac_output_mode_select: CMD_COMMON_V2
+            | {
+                "a6": {
+                    NAME: "set_ac_output_mode",  # Normal (0), Smart (1)
+                    TYPE: DeviceHexDataTypes.ui.value,
+                    STATE_NAME: "ac_output_mode",
+                    VALUE_OPTIONS: {"normal": 0, "smart": 1},
+                },
+            },
+        },
+        "0102": {
+            # DC command group
+            COMMAND_LIST: [
+                SolixMqttCommands.dc_output_switch,  # field a2
+                SolixMqttCommands.dc_12v_output_mode_select,  # field a4
+            ],
+            SolixMqttCommands.dc_output_switch: CMD_COMMON_V2
+            | {
+                "a2": {
+                    NAME: "set_dc_output_switch",  # Disable (0) | Enable (1)
+                    TYPE: DeviceHexDataTypes.ui.value,
+                    STATE_NAME: "dc_output_power_switch",
+                    VALUE_OPTIONS: {"off": 0, "on": 1},
+                },
+            },
+            SolixMqttCommands.dc_12v_output_mode_select: CMD_COMMON_V2
+            | {
+                "a4": {
+                    NAME: "set_dc_12v_output_mode",  # Normal (0), Smart (0)
+                    TYPE: DeviceHexDataTypes.ui.value,
+                    STATE_NAME: "dc_12v_output_mode",
+                    VALUE_OPTIONS: {"normal": 0, "smart": 1},
+                },
+            },
+        },
+        "0103": {
+            # Other command group
+            COMMAND_LIST: [
+                SolixMqttCommands.display_switch,  # field a2
+                SolixMqttCommands.display_mode_select,  # field a3
+                SolixMqttCommands.display_timeout_seconds,  # field a4
+                SolixMqttCommands.device_timeout_minutes,  # field a6
+                SolixMqttCommands.port_memory_switch,  # field a8
+                SolixMqttCommands.soc_limits,  # field aa, ab
+            ],
+            SolixMqttCommands.display_switch: CMD_COMMON_V2
+            | {
+                "a2": {
+                    NAME: "set_display_switch",  # Off (0), On (1)
+                    TYPE: DeviceHexDataTypes.ui.value,
+                    STATE_NAME: "display_switch",
+                    VALUE_OPTIONS: {"off": 0, "on": 1},
+                },
+            },
+            SolixMqttCommands.display_mode_select: CMD_COMMON_V2
+            | {
+                "a3": {
+                    NAME: "set_display_mode",  # Low (1), Medium (2), High (3)
+                    TYPE: DeviceHexDataTypes.ui.value,
+                    STATE_NAME: "display_mode",
+                    VALUE_OPTIONS: {"low": 1, "medium": 2, "high": 3},
+                },
+            },
+            SolixMqttCommands.display_timeout_seconds: CMD_COMMON_V2
+            | {
+                "a4": {
+                    NAME: "set_display_timeout_sec",  # 0 (Never), 10, 20, 30, 60, 300, 1800
+                    TYPE: DeviceHexDataTypes.sile.value,
+                    STATE_NAME: "display_timeout_seconds",
+                    VALUE_OPTIONS: [0, 10, 20, 30, 60, 300, 1800],
+                },
+            },
+            SolixMqttCommands.device_timeout_minutes: CMD_COMMON_V2
+            | {
+                "a6": {
+                    NAME: "set_device_timeout_min",  # 0 (Never), 30, 60, 120, 240, 360, 720, 1440
+                    TYPE: DeviceHexDataTypes.sile.value,
+                    STATE_NAME: "device_timeout_minutes",
+                    VALUE_OPTIONS: [0, 30, 60, 120, 240, 360, 720, 1440],
+                },
+            },
+            SolixMqttCommands.port_memory_switch: CMD_COMMON_V2
+            | {
+                "a8": {
+                    NAME: "set_port_memory_switch",  # Off (0), On (1)
+                    TYPE: DeviceHexDataTypes.ui.value,
+                    STATE_NAME: "port_memory_switch",
+                    VALUE_OPTIONS: {"off": 0, "on": 1},
+                },
+            },
+            SolixMqttCommands.soc_limits: CMD_SOC_LIMITS_V2,
+            # Contains fields aa ab for the limits
+            # aa = max_soc: 80, 85, 90, 95, 100 %
+            # ab = min_soc: 1, 5, 10, 15, 20 %
+        },
+        # Interval: ~3-5 seconds, but only with realtime trigger
+        "0421": _AS220_0421,
+        # Interval: Irregular, triggered on app actions, no fixed interval
+        "0830": _PPS_VERSIONS_0830,
+        # Interval: Irregular, maybe on changes or as response to App status request? Same content as 0421
+        "0900": _AS220_0421,
     },
     # Power Panel
     "A17B1": {

--- a/custom_components/anker_solix/translations/en.json
+++ b/custom_components/anker_solix/translations/en.json
@@ -295,6 +295,39 @@
             }
         },
         "binary_sensor": {
+            "silent_mode": {
+                "name": "Silent mode",
+                "state": {
+                    "on": "On",
+                    "off": "Off"
+                },
+                "state_attributes": {
+                    "weekdays": {
+                        "name": "Weekdays"
+                    },
+                    "start": {
+                        "name": "Start"
+                    },
+                    "end": {
+                        "name": "End"
+                    }
+                }
+            },
+            "custom_mode": {
+                "name": "Custom mode schedule",
+                "state": {
+                    "on": "On",
+                    "off": "Off"
+                },
+                "state_attributes": {
+                    "weekdays": {
+                        "name": "Weekdays"
+                    },
+                    "slots": {
+                        "name": "Slots"
+                    }
+                }
+            },
             "wifi_connection": {
                 "name": "Wifi connection",
                 "state": {
@@ -1084,6 +1117,35 @@
             },
             "ac_input_power": {
                 "name": "AC input power"
+            },
+            "ac_output_working_mode": {
+                "name": "AC output working mode",
+                "state": {
+                    "standard": "Standard (UPS)",
+                    "time_of_use": "Time of Use",
+                    "self_consumption": "Self-Consumption",
+                    "custom": "Custom"
+                },
+                "state_attributes": {
+                    "mode_code": {
+                        "name": "Mode code"
+                    },
+                    "backup_power_soc": {
+                        "name": "Backup reserve %"
+                    },
+                    "max_soc": {
+                        "name": "Max SOC %"
+                    },
+                    "tou_period_count": {
+                        "name": "TOU periods"
+                    }
+                }
+            },
+            "backup_power_soc": {
+                "name": "Backup power reserve"
+            },
+            "smart_ac_output_timeout": {
+                "name": "Smart AC output timeout"
             },
             "ac_input_power_total": {
                 "name": "AC input power_total"


### PR DESCRIPTION
# Add Anker SOLIX S2000 (AS220) support

Adds support for the **Anker SOLIX S2000** (part number `AS220`, device code `DPTC`), a
~2,009.6 Wh / 1,500 W portable power station. Before this change the S2000 registered in HA as
a bare device with no power data — it is a standalone PPS whose model was not yet decoded, so
the Anker cloud returns nothing and its MQTT payloads were undecoded.

## How this was validated (decoded from a real device, not guessed)

Everything below was derived from **MQTT frames captured from an actual S2000** and checked
field-by-field against the device's live values and the Anker app.

The `0421`/`0900` telemetry is **structurally identical to the SOLIX C2000 Gen 2 (`A1783`)** —
same tags, same byte offsets — so the map is forked from `A1783` and then confirmed.

**Core telemetry, cross-checked across opposite states (discharge vs. charge):**

| Field | Discharge | Charge | Check |
|---|---|---|---|
| `battery_soc` | 26 | 45 | matches display |
| `output_power_total` | 0 → **18 W** | 0 | tracked an applied load |
| `ac_input_power` | 0 | **1091 W** | 0 on discharge, real on charge |
| `battery_energy` | — | 900 Wh | = 45 % × 2000 (capacity correct) |
| `temperature` | 20 °C | 29 °C | plausible |
| `battery_status` | discharging | charging | flips correctly |
| `ac_frequency` / `ac_input_limit` | 60 / 1200 | — | US unit |

**AS220-specific fields — decoded by toggling each function and watching which byte moved:**

- **AC output mode** (`d9`): switching Standard → Time-of-Use → Self-Consumption → Custom drove
  `d9[0:2]` (`0/3/4/5` and index `0/1/2/3`); confirmed it's an enum by switching back to
  Standard (returned to `0`, didn't keep counting).
- **Silent-mode schedule** (`df`): `01 7f 7404 b004` = enabled, all days (`0x7f`), 19:00–20:00
  (1140–1200 min). Editing the end-time → `ec04` (21:00) and days → `1f` (Mon–Fri) moved exactly
  the predicted bytes.
- **Custom charge/discharge schedule** (`dd`): `01 1f 02 | 01 0000 3c00 | 02 3c00 7800` =
  weekdays, 2 slots, **charge** 00:00–01:00, **discharge** 01:00–02:00 — matched the app screen.
- **Time-of-Use plan** (`d9` triplets): 5 periods `{type, start_hr, end_hr}` (type 1=Peak,
  2=Mid, 3=Off) matching the app's `00–07 off / 07–11 mid / 11–17 peak / 17–19 mid / 19–24 off`.
- **Smart AC output timeout** (`a4[28]`): 240 ↔ 720 min = 4 h ↔ 12 h.
- `min_soc` (`d9[04]`) preserved so it still feeds `power_cutoff` / the `soc_min` select.

## What's added

**`solixapi/`** (first commit): `AS220` → `SolixDeviceType.PPS` in `SolixDeviceCategory`,
`SolixDeviceCapacity` (2 kWh), the device-overview table, the PPS MQTT `MODELS` set, and
`SOLIXMQTTMAP["AS220"]` (a forked `_AS220_0421` telemetry var + explicit section).

**Integration entities** (second commit): read-only `sensor.ac_output_working_mode` (enum),
`sensor.backup_power_reserve`, `sensor.smart_ac_output_timeout`, and
`binary_sensor.silent_mode` / `binary_sensor.custom_mode` (weekday/time schedule as attributes),
plus `en.json` translations and icons.

## Notes / limitations

- **Read-only for now.** Only device→cloud *state* frames were captured, not the app→device
  *command* frames, so mode/backup/schedules are surfaced but not writable yet. Writable
  controls can follow once commands are captured.
- AS220 reports a **single aggregate USB output** field (not per-port), and has **no** separate
  DC-12V or AC-output-mode selects — those inherited from `A1783` are intentionally not created.
- Tags `a8`/`dc`/`de` stayed all-zero through AC in/out + USB and could not be exercised (they
  appear to need solar PV / a car port / an expansion battery, unavailable on the test unit).

## Data

An anonymized `export_systems` capture of the S2000 (raw MQTT frames) is available on request.
