### PR TITLE
Fix A17C5 max load control via MQTT

### DIFF
--- a/custom_components/anker_solix/select.py
+++ b/custom_components/anker_solix/select.py
@@ -252,7 +252,7 @@ DEVICE_SELECTS = [
             None
             if (
                 v := (d.get(jk) or d.get("power_limit"))
-                if d.get(MQTT_OVERLAY)
+                if d.get(MQTT_OVERLAY) or d.get("device_pn") == "A17C5"
                 else (d.get("power_limit") or d.get(jk))
             )
             is None
@@ -987,6 +987,11 @@ async def async_setup_entry(
                             # include MQTT command select entities only if no switch and max 20 options or also using Api command
                             and (
                                 desc.api_cmd
+                                or (
+                                    desc.key == "max_load"
+                                    and data.get("device_pn") == "A17C5"
+                                    and desc.mqtt_cmd == SolixMqttCommands.sb_max_load
+                                )
                                 or not (
                                     mdev
                                     and desc.mqtt_cmd
@@ -1129,7 +1134,8 @@ class AnkerSolixSelect(CoordinatorEntity, SelectEntity):
             self._attr_options = list(options)
             self._attr_options.sort()
         elif mdev and (
-            self.entity_description.mqtt_cmd
+            data.get("device_pn") != "A17C5"
+            and self.entity_description.mqtt_cmd
             in [SolixMqttCommands.sb_max_load, SolixMqttCommands.sb_max_load_parallel]
             and isinstance(options := mdev.device.get("power_limit_option"), list)
         ):
@@ -1585,8 +1591,12 @@ class AnkerSolixSelect(CoordinatorEntity, SelectEntity):
                         "entity_id": self.entity_id,
                     },
                 )
-            # Skip Api calls if entity does not change
-            if str(option) == str(self._attr_current_option):
+            # Skip calls if entity does not change, except A17C5 max_load where
+            # the cached cloud value can differ from the physical MQTT state.
+            if str(option) == str(self._attr_current_option) and not (
+                self._attribute_name == "max_load"
+                and data.get("device_pn") == "A17C5"
+            ):
                 return
             # Wait until client cache is valid before applying any api change
             await self.coordinator.client.validate_cache()
@@ -1704,6 +1714,29 @@ class AnkerSolixSelect(CoordinatorEntity, SelectEntity):
                                     indent=2 if len(json.dumps(resp)) < 200 else None,
                                 ),
                             )
+
+            elif (
+                self._attribute_name == "max_load"
+                and data.get("device_pn") == "A17C5"
+                and mdev
+            ):
+                LOGGER.debug(
+                    "'%s' selection change to option '%s' will be applied via MQTT",
+                    self.entity_id,
+                    option,
+                )
+                # Current A17C5 app changes the output limit with 005a/type 3
+                # followed by 0080/type 0.
+                await self._async_mqtt_option(
+                    mdev=mdev,
+                    option=option,
+                    cmd=SolixMqttCommands.sb_max_load_parallel,
+                )
+                await self._async_mqtt_option(
+                    mdev=mdev,
+                    option=option,
+                    cmd=SolixMqttCommands.sb_max_load,
+                )
 
             elif self._attribute_name in ["max_load", "max_load_total"]:
                 LOGGER.debug(

--- a/custom_components/anker_solix/solixapi/mqttmap.py
+++ b/custom_components/anker_solix/solixapi/mqttmap.py
@@ -5747,17 +5747,16 @@ SOLIXMQTTMAP: Final[dict] = {
     "A17C5": {
         "0050": CMD_TEMP_UNIT,  # Temperature unit switch: Celsius (0) or Fahrenheit (1)
         "0057": CMD_REALTIME_TRIGGER,  # for regular status messages 0405 etc
-        "005a": CMD_SB_MAX_LOAD  # same pattern but different command for max load settings in parallel systems
+        "005a": CMD_SB_MAX_LOAD  # first A17C5 max-load command used by current app
         | {
             COMMAND_NAME: SolixMqttCommands.sb_max_load_parallel,
             "a2": {
                 **CMD_SB_MAX_LOAD["a2"],
-                VALUE_OPTIONS: [1200, 2400, 3600, 4800],
-                VALUE_OPTIONS_STATE: "max_load_parallel_options",
+                VALUE_OPTIONS: list(range(100, 801, 10)),
             },
             "a3": {
                 **CMD_SB_MAX_LOAD["a3"],
-                VALUE_DEFAULT: 2,
+                VALUE_DEFAULT: 3,
             },
         },
         "005e": CMD_SB_USAGE_MODE,  # NOTE: Cmd not supported directly, but description used for msg decoding
@@ -5794,12 +5793,11 @@ SOLIXMQTTMAP: Final[dict] = {
                 SolixMqttCommands.sb_pv_limit_select,  # field a7
                 SolixMqttCommands.sb_ac_input_limit,  # field a8
             ],
-            SolixMqttCommands.sb_max_load: CMD_SB_MAX_LOAD  # 350,600,800,1000,1200 W, may depend on country settings
+            SolixMqttCommands.sb_max_load: CMD_SB_MAX_LOAD  # current A17C5: 100-800 W, step 10 W
             | {
                 "a2": {
                     **CMD_SB_MAX_LOAD["a2"],
-                    VALUE_OPTIONS: [350, 600, 800, 1000, 1200],
-                    VALUE_OPTIONS_STATE: "max_load_options",  # key to be used to provide valid options
+                    VALUE_OPTIONS: list(range(100, 801, 10)),
                 },
                 # Extra field a4 observed for SB3, which does not seem to be used for SB2?
                 "a4": {


### PR DESCRIPTION
## Summary

Fix the `max_load` control for the Solarbank 3 E2700 Pro (`A17C5`).

The current Anker app supports an output limit from 100 W to 800 W in 10 W steps. For A17C5, changing this limit uses two MQTT commands:

1. `005a` with `set_max_load=<value>` and `set_max_load_type=3`
2. `0080` with `set_max_load=<value>` and `set_max_load_type=0`

The existing integration still used older option ranges for A17C5 and routed the setting through the cloud `set_power_limit` path.

## Changes

- Update A17C5 `max_load` options to 100–800 W in 10 W steps.
- Use `set_max_load_type=3` for the A17C5 `005a` command.
- Send the A17C5 max-load change through MQTT using:
  - `005a` / type 3
  - followed by `0080` / type 0
- Avoid replacing the A17C5 MQTT option range with the stale cloud `power_limit_option` values.
- Prefer the MQTT-reported `max_load` value for A17C5.
- Do not suppress an A17C5 max-load command as a no-op when the cached cloud/entity value differs from the actual MQTT device state.
- Keep the behavior scoped to A17C5; other Solarbank models keep their existing control path.

## Testing

Tested with a Solarbank 3 E2700 Pro (`A17C5`) using live MQTT monitoring.

### Set to 100 W

Home Assistant sent:

- `005a`: `set_max_load=100`, `set_max_load_type=3`
- `0080`: `set_max_load=100`, `set_max_load_type=0`

The following device status reported:

- `max_load=100`
- `max_load_legal=800`

The measured AC output settled at approximately 98–100 W while the home demand was higher.

### Restore to 800 W

Home Assistant sent:

- `005a`: `set_max_load=800`, `set_max_load_type=3`
- `0080`: `set_max_load=800`, `set_max_load_type=0`

The following device status reported:

- `max_load=800`
- `max_load_legal=800`

## Validation

- `ruff check . --fix` passes
- `python -m py_compile` passes for the modified files
- `git diff --check` passes
- Live MQTT round-trip verified for both 100 W and 800 W

Raw MQTT captures contain device/account identifiers, so they are not attached unchanged. Anonymized excerpts can be provided if needed.