### PR TITLE
Add usage mode (0090) support for A1783 / SOLIX C2000 Gen 2

### DIFF
--- a/custom_components/anker_solix/select.py
+++ b/custom_components/anker_solix/select.py
@@ -536,7 +536,9 @@ DEVICE_SELECTS = [
         translation_key="pps_usage_mode",
         json_key="usage_mode",
         # option values are mdev functions, depending on charger feature settings
-        value_fn=lambda d, jk: d.get(jk),
+        # Fall back to the customized cache so models that never report
+        # usage_mode still show the mode that was last selected.
+        value_fn=lambda d, jk: d.get(jk) or (d.get("customized") or {}).get(jk),
         attrib_fn=lambda d, jk: (
             {"mode": d.get(jk)}
             | (
@@ -553,6 +555,11 @@ DEVICE_SELECTS = [
         exclude_fn=lambda s, d: (
             not (({d.get("type")} - s) & {SolixDeviceType.PPS.value})
         ),
+        # A1783 accepts the 0090 usage mode command but never reports
+        # usage_mode in its telemetry, so neither entity creation nor the
+        # write path would otherwise run for it.
+        force_creation_fn=lambda d, _: d.get("device_pn") in {"A1783"},
+        restore=True,
         mqtt=True,
         mqtt_cmd=SolixMqttCommands.pps_usage_mode,
     ),

--- a/custom_components/anker_solix/solixapi/mqttmap.py
+++ b/custom_components/anker_solix/solixapi/mqttmap.py
@@ -4798,6 +4798,26 @@ SOLIXMQTTMAP: Final[dict] = {
             # aa = max_soc: 80, 85, 90, 95, 100 %
             # ab = min_soc: 1, 5, 10, 15, 20 %
         },
+        "0090": {
+            # TOU command group, same shape as the AS220 definition below.
+            COMMAND_LIST: [
+                SolixMqttCommands.pps_usage_mode,  # field a2
+            ],
+            SolixMqttCommands.pps_usage_mode: CMD_COMMON_V2
+            | {
+                "a2": {  # 0=Standard, 1=Time-of-Use, 2=Self-Consumption, 3=Custom
+                    NAME: "set_usage_mode",
+                    TYPE: DeviceHexDataTypes.ui.value,
+                    STATE_NAME: "usage_mode",
+                    VALUE_OPTIONS: {
+                        "standard": 0,  # UPS mode
+                        "time_of_use": 1,
+                        "self_consumption": 2,
+                        "custom": 3,
+                    },
+                },
+            },
+        },
         # Interval: ~3-5 seconds, but only with realtime trigger
         "0421": _A1783_0421,
         # Interval: Irregular, triggered on app actions, no fixed interval


### PR DESCRIPTION
Hi, and thank you for this integration — it's a genuinely impressive piece of
reverse engineering, and the model maps made it straightforward to work out what
was going on with my device. Please treat everything below as a suggestion rather
than a request; you know this codebase far better than I do and may well prefer a
different approach.

## What this adds

Usage mode (Standard/UPS ↔ Time-of-Use) control for the **A1783 — SOLIX C2000 Gen 2**.

`pps_usage_mode` is already listed in `mqtt_pps.FEATURES` for all PPS models, but the
`A1783` block has no message group carrying it, so no select entity is created and the
mode can only be changed from the app.

## How the command was identified

I subscribed to `cmd/anker_power/A1783/<sn>/#` on the Anker broker using the
credentials from `get_user_mqtt_info`, then toggled usage mode in the app:

```
app -> type=0090  a2=01 00   ->  charging_status 1 -> 2  (charging started)
app -> type=0090  a2=01 01   ->  charging_status 2 -> 1  (stopped, ac_input 0 W)
```

The TLV value is `<byte-count><little-endian value>`, so `01 00` = value `0` and
`01 01` = value `1` — matching the existing `SolixPpsUsageMode` enum
(`standard=0`, `time_of_use=1`).

As a sanity check on my reading of the encoding, the realtime trigger in the same
capture sent `a2=01 01, a3=02 2c01`, and `0x012c` LE = 300, which matches the
documented 300 s trigger timeout default.

The group turns out to be identical to the `0090` group already defined for `AS220`
— which makes sense given the comment noting AS220 was derived from this model. So
this is really just restoring a group the map already describes elsewhere.

## The two `select.py` changes

These are the part I'm least sure about, and I'd completely understand if you'd
rather solve it differently.

The A1783 doesn't report `usage_mode` in its telemetry, only accepts it as a command.
That trips two separate guards:

1. **Entity creation** — `async_setup_entry` requires
   `desc.value_fn(...) is not None`, so the select is never created. Hence
   `force_creation_fn`, scoped to `A1783` since that's the only model I could test.

2. **Writes** — `async_select_option` wraps its whole body in
   `... and (self._attr_current_option is not None or self.entity_description.restore)`.
   With no reported state and `restore` defaulting to `False`, the call returns
   silently: no log, no exception, and the service call still reports success. I only
   found it by tracing the code, so I thought it worth flagging even aside from this
   PR — it's a quiet failure mode for any write-only MQTT select.

   I've used `restore=True` (following `dynamic_price_provider`) plus a `value_fn`
   fallback to the customized cache so the chosen mode is displayed rather than
   `unknown`. A more general alternative would be relaxing that guard for entities
   with an `mqtt_cmd`, but that felt too invasive for me to propose unilaterally.

## Testing

Verified on an A1783 (firmware 1.2.1.1, one expansion pack, owner account):
selecting `standard` took the unit from 0 W to ~2.1 kW AC input and the app
reflected the mode change; selecting `time_of_use` stopped charging entirely.
Round-tripped several times. No errors in the log.

I haven't touched `backup_soc` (field `a5` in the AS220 `0090` group) as I had no way
to exercise it, so it's deliberately left out rather than assumed.

Happy to adjust scope, naming, or the `select.py` approach — or to split the map
change and the `select.py` change into separate PRs if that's easier to review.
Thanks again for maintaining this.
